### PR TITLE
レポジトリのリセット前に質問するようにした

### DIFF
--- a/packages/github_browser_app/l10n/app_en.arb
+++ b/packages/github_browser_app/l10n/app_en.arb
@@ -1,4 +1,17 @@
 {
   "@@locale":"en",
-  "inputSearchWord": "Input search word"
+  "inputSearchWord": "Input search word",
+  "resetConfirmation": "Do you want to reset?",
+  "repositoriesDeletedKeepKeyword": "Loaded repositories will be deleted, but {keyword} will be retained",
+    "@repositoriesDeletedKeepKeyword": {
+      "placeholders": {
+        "keyword": {
+          "type": "String",
+          "example": "flutter"
+        }
+      }
+    },
+  "cancelAction": "Cancel",
+  "resetAction": "Reset",
+  "end":"end"
 }

--- a/packages/github_browser_app/l10n/app_ja.arb
+++ b/packages/github_browser_app/l10n/app_ja.arb
@@ -1,4 +1,9 @@
 {
   "@@locale":"ja",
-  "inputSearchWord": "検索ワードを入れてください"
+  "inputSearchWord": "検索ワードを入れてください",
+  "resetConfirmation": "リセットしますか",
+  "repositoriesDeletedKeepKeyword": "読み込んだレポジトリは削除されますが、{keyword}は維持されます",
+  "cancelAction": "キャンセルする",
+  "resetAction": "リセットする",
+  "end":"end"
 }

--- a/packages/github_browser_app/lib/pages/search_repositories/ask_before_reset.dart
+++ b/packages/github_browser_app/lib/pages/search_repositories/ask_before_reset.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+abstract interface class AskIfReset {
+  Future<bool?> askIfReset(BuildContext context, String keyword);
+}

--- a/packages/github_browser_app/lib/pages/search_repositories/search_repositories_page.dart
+++ b/packages/github_browser_app/lib/pages/search_repositories/search_repositories_page.dart
@@ -3,6 +3,7 @@ import 'package:domain/exceptions/exceptions_when_loading_repositories.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_browser_app/extensions/responsive_extension.dart';
+import 'package:github_browser_app/pages/search_repositories/ask_before_reset.dart';
 import 'package:modeless_drawer/modeless_drawer.dart';
 import 'package:github_browser_app/gen_l10n/app_localizations.dart';
 
@@ -13,7 +14,7 @@ part 'search_repositories_page.detail_drawer.dart';
 part 'search_repositories_page.keyword_text_field.dart';
 part 'search_repositories_page.search_cancel_button.dart';
 
-class SearchRepositoriesPage extends ConsumerWidget {
+class SearchRepositoriesPage extends ConsumerWidget implements AskIfReset {
   const SearchRepositoriesPage({super.key});
 
   @override
@@ -71,7 +72,7 @@ class SearchRepositoriesPage extends ConsumerWidget {
                           isKeywordEmpty: isKeywordEmpty,
                           onReset: () => ref
                               .read(searchRepositoriesStateProvider.notifier)
-                              .reset(),
+                              .resetAfterAsk(this, context),
                           onSearch: () => onSearch(
                               context,
                               ref.read(
@@ -169,6 +170,28 @@ class SearchRepositoriesPage extends ConsumerWidget {
       context,
       () => notifier.loadRepositories(),
       onError: notifier.reset,
+    );
+  }
+
+  @override
+  Future<bool?> askIfReset(BuildContext context, String keyword) {
+    return showAdaptiveDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog.adaptive(
+        title: Text(AppLocalizations.of(context).resetConfirmation),
+        content: Text(AppLocalizations.of(context)
+            .repositoriesDeletedKeepKeyword(keyword)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(AppLocalizations.of(context).cancelAction),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(AppLocalizations.of(context).resetAction),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/github_browser_app/lib/pages/search_repositories/search_repositories_state.dart
+++ b/packages/github_browser_app/lib/pages/search_repositories/search_repositories_state.dart
@@ -1,5 +1,7 @@
 import 'package:domain/service_locator.dart';
 import 'package:domain/use_case/search_repositories_use_case.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:github_browser_app/pages/search_repositories/ask_before_reset.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'search_repositories_model.dart';
@@ -11,7 +13,7 @@ class SearchRepositoriesState extends _$SearchRepositoriesState {
       ServiceLocator.singleton().useCaseList.getSearchRepositoriesUseCase();
 
   @override
-  SearchRepositoriesModel build() => SearchRepositoriesModel(
+  SearchRepositoriesModel build() => const SearchRepositoriesModel(
         keyword: '',
         isSearched: false,
         page: 1,
@@ -41,5 +43,22 @@ class SearchRepositoriesState extends _$SearchRepositoriesState {
       isLoading: false,
       entities: [...state.entities, ...repositories],
     );
+  }
+
+  Future<void> resetAfterAsk(
+      AskIfReset humbleObject, BuildContext context) async {
+    // レポジトリ読み込み中は、キャンセルできないとする
+    if (state.isLoading) {
+      return;
+    }
+
+    final result = await humbleObject.askIfReset(
+      context,
+      state.keyword,
+    );
+
+    if (result == true) {
+      reset();
+    }
   }
 }

--- a/packages/github_browser_app/pubspec.yaml
+++ b/packages/github_browser_app/pubspec.yaml
@@ -53,6 +53,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   build_runner: ^2.4.13
   riverpod_generator: ^2.4.3
+  mockito: ^5.4.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/github_browser_app/test/pages/search_repositories/search_repositories_state_test.dart
+++ b/packages/github_browser_app/test/pages/search_repositories/search_repositories_state_test.dart
@@ -1,0 +1,193 @@
+import 'package:domain/entities/git_repository_entity.dart';
+import 'package:domain/service_locator.dart';
+import 'package:domain/use_case/search_repositories_use_case.dart';
+import 'package:domain/use_case/use_case_list.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser_app/pages/search_repositories/ask_before_reset.dart';
+import 'package:github_browser_app/pages/search_repositories/search_repositories_state.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
+import 'search_repositories_state_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<UseCaseList>(),
+  MockSpec<SearchRepositoriesUseCase>(),
+  MockSpec<AskIfReset>(),
+  MockSpec<BuildContext>()
+])
+void main() {
+  final mockSearchRepositoriesUseCase = MockSearchRepositoriesUseCase();
+  final mockUserCaseList = MockUseCaseList();
+  when(mockUserCaseList.getSearchRepositoriesUseCase())
+      .thenReturn(mockSearchRepositoriesUseCase);
+  ServiceLocator.init(http.Client(), mockUserCaseList);
+
+  late ProviderContainer container;
+
+  final searchRepositoriesState = SearchRepositoriesState();
+  setUp(() {
+    container = ProviderContainer(); // ProviderContainerを作成
+  });
+  tearDown(() {
+    container.dispose(); // テスト終了後にProviderContainerを破棄
+  });
+
+  test('Initial state should have default values', () {
+    final initialState = searchRepositoriesState.build();
+    expect(initialState.keyword, '');
+    expect(initialState.isSearched, false);
+    expect(initialState.page, 1);
+    expect(initialState.isLoading, false);
+    expect(initialState.entities, []);
+  });
+
+  test('changeKeyword updates the keyword in the state', () {
+    final initState = container.read(searchRepositoriesStateProvider);
+    expect(initState.keyword, '');
+
+    container
+        .read(searchRepositoriesStateProvider.notifier)
+        .changeKeyword('flutter');
+
+    final updatedState = container.read(searchRepositoriesStateProvider);
+    expect(updatedState.keyword, 'flutter');
+  });
+
+  test('loadRepositories updates state with repositories', () async {
+    final repositories = [
+      for (int i = 0; i < 2; i++)
+        GitRepositoryEntity(
+            authorName: '',
+            repositoryName: 'repository$i',
+            description: '',
+            authorImage: '',
+            stargazersCount: 0,
+            forksCount: 0,
+            issuesCount: 0,
+            watchersCount: 0,
+            lastUpdatedAt: DateTime.now())
+    ];
+
+    final initialState = container.read(searchRepositoriesStateProvider);
+    expect(initialState.keyword, '');
+    expect(initialState.isSearched, false);
+    expect(initialState.page, 1);
+    expect(initialState.isLoading, false);
+    expect(initialState.entities, []);
+
+    when(mockSearchRepositoriesUseCase.loadGitRepositories(any, any))
+        .thenAnswer((_) async => repositories);
+
+    final future = container
+        .read(searchRepositoriesStateProvider.notifier)
+        .loadRepositories();
+
+    final beforeLoading = container.read(searchRepositoriesStateProvider);
+    expect(beforeLoading.keyword, '');
+    expect(beforeLoading.isSearched, true);
+    expect(beforeLoading.page, 1);
+    expect(beforeLoading.isLoading, true);
+    expect(beforeLoading.entities, []);
+
+    await future;
+    verify(mockSearchRepositoriesUseCase.loadGitRepositories('', 1)).called(1);
+
+    final afterLoading = container.read(searchRepositoriesStateProvider);
+    expect(afterLoading.keyword, '');
+    expect(afterLoading.isSearched, true);
+    expect(afterLoading.page, 2);
+    expect(afterLoading.isLoading, false);
+    expect(afterLoading.entities.length, 2);
+    expect(afterLoading.entities, repositories);
+
+    await container
+        .read(searchRepositoriesStateProvider.notifier)
+        .loadRepositories();
+    verify(mockSearchRepositoriesUseCase.loadGitRepositories('', 2)).called(1);
+
+    final afterSecondLoading = container.read(searchRepositoriesStateProvider);
+    expect(afterSecondLoading.page, 3);
+    expect(afterSecondLoading.entities.length, 4);
+  });
+
+  test('resets', () async {
+    final repositories = [
+      for (int i = 0; i < 2; i++)
+        GitRepositoryEntity(
+            authorName: '',
+            repositoryName: 'repository$i',
+            description: '',
+            authorImage: '',
+            stargazersCount: 0,
+            forksCount: 0,
+            issuesCount: 0,
+            watchersCount: 0,
+            lastUpdatedAt: DateTime.now())
+    ];
+
+    when(mockSearchRepositoriesUseCase.loadGitRepositories(any, any))
+        .thenAnswer((_) async => repositories);
+
+    container
+        .read(searchRepositoriesStateProvider.notifier)
+        .changeKeyword('keyword');
+    await container
+        .read(searchRepositoriesStateProvider.notifier)
+        .loadRepositories();
+
+    final afterLoading = container.read(searchRepositoriesStateProvider);
+    expect(afterLoading.keyword, 'keyword');
+    expect(afterLoading.isSearched, true);
+    expect(afterLoading.page, 2);
+    expect(afterLoading.isLoading, false);
+    expect(afterLoading.entities.length, 2);
+    expect(afterLoading.entities, repositories);
+
+    container.read(searchRepositoriesStateProvider.notifier).reset();
+    final afterReset = container.read(searchRepositoriesStateProvider);
+    expect(afterReset.keyword, 'keyword');
+    expect(afterReset.isSearched, false);
+    expect(afterReset.page, 1);
+    expect(afterReset.isLoading, false);
+    expect(afterReset.entities.length, 0);
+  });
+
+  group('resetAfterAsk', () {
+    final askIfReset = MockAskIfReset();
+    final notifier =
+        () => container.read(searchRepositoriesStateProvider.notifier);
+    final state = () => container.read(searchRepositoriesStateProvider);
+
+    final context = MockBuildContext();
+
+    test('false: キャンセルを押すと、リセットしない', () async {
+      notifier().changeKeyword('keyword');
+      when(askIfReset.askIfReset(context, 'keyword'))
+          .thenAnswer((_) async => false);
+      expect(state().entities.length, 0);
+      await notifier().loadRepositories();
+      expect(state().keyword, 'keyword');
+      expect(state().entities.length, 2);
+
+      await notifier().resetAfterAsk(askIfReset, context);
+      expect(state().entities.length, 2);
+    });
+
+    test('true： リセットする', () async {
+      when(askIfReset.askIfReset(context, 'keyword'))
+          .thenAnswer((_) async => true);
+      expect(state().entities.length, 0);
+      notifier().changeKeyword('keyword');
+      await notifier().loadRepositories();
+      expect(state().entities.length, 2);
+
+      await notifier().resetAfterAsk(askIfReset, context);
+      expect(state().keyword, 'keyword');
+      expect(state().entities.length, 0);
+    });
+  });
+}


### PR DESCRIPTION
ページのRiverpodのStateのテストを追加した。ダイアログの選択肢の決定もHumbleObjectパターンを使用して実行している