### PR TITLE
dependenciesにflutterを入れておく

### DIFF
--- a/packages/domain/pubspec.yaml
+++ b/packages/domain/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
+  flutter:
+    sdk: flutter
   http: ^1.2.2
 
 

--- a/packages/infrastructure/pubspec.yaml
+++ b/packages/infrastructure/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
+  flutter:
+    sdk: flutter
   domain:
     path: ../domain
   http: ^1.2.2

--- a/packages/use_case/pubspec.yaml
+++ b/packages/use_case/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
+  flutter:
+    sdk: flutter
   domain:
     path: ../domain
   infrastructure:


### PR DESCRIPTION
パッケージ自体がFlutterに依存してない場合でも、dependenciesにflutterが入ってないと、テスト実施時にAndroidStudio上で右クリックでテスト実行するとエラーになる場合がある。安全に寄せて、dependenciesにflutterを入れておく。コマンドラインからはテストできた